### PR TITLE
Update hashring dependency for iojs compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "http://github.com/3rd-Eden/node-memcached.git"
   },
   "dependencies": {
-    "hashring": "3.0.x",
+    "hashring": "3.1.x",
     "jackpot": ">=0.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This module is not currently compatible with iojs. This PR fixes that.

see: iojs/io.js#456