### PR TITLE
Fix slow V8 string operations in node 0.10

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -341,7 +341,7 @@ Client.config = {
       // used for request timing
       query.start = Date.now();
       S.metaData.push(query);
-      S.write(query.command + LINEBREAK);
+      S.write(Utils.reallocString(query.command + LINEBREAK));
     });
 
     // if we have redundancy enabled and the query is used for redundancy, than
@@ -656,13 +656,7 @@ Client.config = {
     // only call transform the data once we are sure, 100% sure, that we valid
     // response ending
     if (S.responseBuffer.substr(S.responseBuffer.length - 2) === LINEBREAK) {
-
-      // Force v8 to re-allocate the responseBuffer and free the BufferStream
-      // chunks that were appended to it. This works around an issue in v8 where
-      // it doesn't free the appended strings which can cause poor GC behavior
-      // and make this function very slow for larger key values.
-      // See: https://code.google.com/p/v8/issues/detail?id=2869
-      S.responseBuffer = (' ' + S.responseBuffer).substr(1);
+      S.responseBuffer = Utils.reallocString(S.responseBuffer);
 
       var chunks = S.responseBuffer.split(LINEBREAK);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,7 +66,7 @@ exports.validateArg = function validateArg (args, config) {
           if (result.err) {
             err = result.err;
           } else {
-            args.command = args.command.replace(value, result['value']);
+            args.command = reallocString(args.command).replace(value, result['value']);
           }
         }
         break;
@@ -155,4 +155,10 @@ exports.escapeValue = function(value) {
 //Unescapes escaped values by removing backslashes before line breaks
 exports.unescapeValue = function(value) {
   return value.replace(/\\(\r|\n)/g, '$1');
+};
+
+var reallocString = exports.reallocString = function(value) {
+  // Reallocate string to fix slow string operations in node 0.10
+  // see https://code.google.com/p/v8/issues/detail?id=2869 for details
+  return (' ' + value).substr(1);
 };


### PR DESCRIPTION
I managed to reproduce the issue mentioned in <https://github.com/3rd-Eden/node-memcached/pull/205> with the script below.  Hopefully, you'll be able to see the latency spikes when you run the script (from ~10ms to ~80ms).

Please run on node 0.10.

**slow-set.js**:
```javascript
'use strict';

var Memcached = require('./');

var currentSize = 515000;
var endSize = 525000;
var inc = 100;

function createStringOfSize(size) {
  var buffer = new Buffer(size);
  buffer.fill('x');
  return buffer.toString();
}

function loopUntilComplete() {
  if (currentSize < endSize) return setKey(loopUntilComplete);
  process.exit(0);
}

function setKey(cb) {
  console.time('memcached.set');
  var key = 'default:' + 'foobydoo'; // slow
  //var key = 'default:foobydoo'; // fast
  var value = createStringOfSize(currentSize);

  memcached.set(key, value, 300, function(err) {
    if (err) throw err;
    console.timeEnd('memcached.set');
    console.log("Set cache key foobydoo with object of length " + currentSize);
    currentSize += inc;
    cb(err);
  });
}

var memcached = new Memcached(['localhost:11211'], {
  retry: 1000,
  timeout: 100,
  reconnect: 300000,
  poolSize: 100
});

loopUntilComplete();
```