### PR TITLE
Defend against extended array extensions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,7 @@ exports.validateArg = function validateArg (args, config) {
           err = 'Argument "' + key + '" is not a valid Array.';
         }
         if (!err && key === 'key') {
-          for (var vKey in value) {
+          for (var vKey=0; vKey<value.length; vKey++) {
             var vValue = value[vKey];
             var result = validateKeySize(config, vKey, vValue);
             if (result.err) {


### PR DESCRIPTION
Using `for...in` on Arrays is not robust against libraries that attach additional metadata to array objects or the `Array` prototype. This change switches to direct array iteration, which is always safe.